### PR TITLE
Use polygon bounds

### DIFF
--- a/cabby/data/extract_test.py
+++ b/cabby/data/extract_test.py
@@ -43,8 +43,8 @@ class GeoSetTest(unittest.TestCase):
     self.assertEqual(wikidata_sample.sample_type, 'Wikidata')
     self.assertEqual(
         wikidata_sample.text,
-        ('Birmingham Public School and building in Pennsylvania, United States '
-        'and  and building and Renaissance Revival architecture.')
+        ('Renaissance Revival architecture, building, building in '
+         'Pennsylvania, United States, Birmingham Public School.')
     )
 
     osm_sample = samples[6]

--- a/cabby/data/wikidata/info_item.py
+++ b/cabby/data/wikidata/info_item.py
@@ -66,6 +66,8 @@ class WikidataEntity:
         result
         
     )
+
+
 def create_sample_from_tags(item: Dict) -> Text:
   '''Get a Wikidata item and return a sample based on tags." 
   Arguments:
@@ -73,11 +75,8 @@ def create_sample_from_tags(item: Dict) -> Text:
   Returns:
       A description.
   '''
-  unwanted_tags = ['place', 'point']
-  list_tags = []
-  for k, v in item.items():
-    if k not in unwanted_tags:
-      list_tags.append(v['value'])
-  
-  return ' and '.join(list_tags) + "."
-
+  unwanted_tags = frozenset(['place', 'point'])
+  #tags = [str(item[k]) for k in sorted(item.keys()) if k not in unwanted_tags]
+  item_tags = [item[k]['value'] for k in sorted(item.keys())
+               if k not in unwanted_tags and item[k]['value']]
+  return ', '.join(item_tags) + "."

--- a/cabby/geo/regions.py
+++ b/cabby/geo/regions.py
@@ -24,50 +24,45 @@ from shapely import wkt
 
 @attr.s
 class Region:
-  """Basic information defining a region on the earth's surface.
+  """A polygon defining a region on the earth's surface and a name for it.
   
   `name`: An identifier used to select this region.
   `polygon`: A shapely Polygon defining the bounds of the region.
   `corner_sw`: A shapely Point corresponding to the south-west corner of the
-    region's bounding box.
+    region's bounding box. This is computed from the given polygon.
   `corner_ne`: A shapely Point corresponding to the north-east corner of the
-    region's bounding box.
+    region's bounding box. This is computed from the given polygon.
   """
   name: str = attr.ib()
   polygon: Polygon = attr.ib()
-  corner_sw: Point = attr.ib()
-  corner_ne: Point = attr.ib()
+  corner_sw: Point = attr.ib(init=False)
+  corner_ne: Point = attr.ib(init=False)
+
+  def __attrs_post_init__(self):
+    (minx, miny, maxx, maxy) = self.polygon.bounds
+    self.corner_sw = Point(minx, miny)
+    self.corner_ne = Point(maxx, maxy)
 
 SUPPORTED_REGIONS = [
   Region(
     name='DC',
-    polygon=box(minx=-77.02767, miny=38.96608, maxx=-77.02704, maxy=38.9686),
-    corner_sw=Point(-77.02767, 38.96608),
-    corner_ne=Point(-77.02704, 38.9686)
+    polygon=box(minx=-77.02767, miny=38.96608, maxx=-77.02704, maxy=38.9686)
   ),
   Region(
     name="Manhattan",
     polygon=wkt.loads('POLYGON ((-73.9455846946375 40.7711351085905,-73.9841893202025 40.7873649535321,-73.9976322499213 40.7733311258037,-74.0035177432988 40.7642404854275,-74.0097394992375 40.7563218869601,-74.01237903206 40.741427380319,-74.0159612551762 40.7237048027967,-74.0199205544099 40.7110727528606,-74.0203570671504 40.7073623945662,-74.0188292725586 40.7010329598287,-74.0087894795267 40.7003781907179,-73.9976584046436 40.707144138196,-73.9767057930988 40.7104179837498,-73.9695033328803 40.730061057073,-73.9736502039152 40.7366087481808,-73.968412051029 40.7433746956588,-73.968412051029 40.7433746956588,-73.9455846946375 40.7711351085905))'),
-    corner_sw=Point(-74.0379, 40.6966),
-    corner_ne=Point(-73.9293, 40.7963)
   ),
   Region(
     name='Pittsburgh',
     polygon=box(minx=-80.035, miny=40.425, maxx=-79.930, maxy=40.460, ccw=True),
-    corner_sw=Point(-80.035, 40.425),
-    corner_ne=Point(-79.930, 40.460)
   ),
   Region(
     name='Pittsburgh_small',
     polygon=Point(-79.9837, 40.4273).buffer(0.0015),
-    corner_sw=Point(-79.9837, 40.4273),
-    corner_ne=Point(-79.953274, 40.444565)
   ),
   Region(
     name='UTAustin',
     polygon=box(minx=-97.7418, miny=30.2836, maxx=-97.7360, maxy=30.2872),
-    corner_sw=Point(-97.7418, 30.2836),
-    corner_ne=Point(-97.7360, 30.2872)
   )  
 ]
 


### PR DESCRIPTION
To define a Region, we had to provide the SW and NE corners, e.g. as in:

```
  Region(
    name="Manhattan",
    polygon=wkt.loads('POLYGON ((-73.9455846946375 40.7711351085905,-73.9841893202025 40.7873649535321,-73.9976322499213 40.7733311258037,-74.0035177432988 40.7642404854275,-74.0097394992375 40.7563218869601,-74.01237903206 40.741427380319,-74.0159612551762 40.7237048027967,-74.0199205544099 40.7110727528606,-74.0203570671504 40.7073623945662,-74.0188292725586 40.7010329598287,-74.0087894795267 40.7003781907179,-73.9976584046436 40.707144138196,-73.9767057930988 40.7104179837498,-73.9695033328803 40.730061057073,-73.9736502039152 40.7366087481808,-73.968412051029 40.7433746956588,-73.968412051029 40.7433746956588,-73.9455846946375 40.7711351085905))'),
    corner_sw=Point(-74.0379, 40.6966),
    corner_ne=Point(-73.9293, 40.7963)
  ),
  Region(
    name='Pittsburgh',
    polygon=box(minx=-80.035, miny=40.425, maxx=-79.930, maxy=40.460, ccw=True),
    corner_sw=Point(-80.035, 40.425),
    corner_ne=Point(-79.930, 40.460)
  ),
```

This is silly because the polygon has all the information we need, so this PR fixes that:

```
  def __attrs_post_init__(self):
    (minx, miny, maxx, maxy) = self.polygon.bounds
    self.corner_sw = Point(minx, miny)
    self.corner_ne = Point(maxx, maxy)
```

I also changed the way a textual description is produced for wikidata items so that they are always produced the same way and to use commas rather than ' and ' as the separator.