### PR TITLE
fixed route shortcuts in map.

### DIFF
--- a/cabby/geo/map_processing/edge.py
+++ b/cabby/geo/map_processing/edge.py
@@ -36,6 +36,7 @@ class Edge:
   u_for_edge: int = attr.ib()
   v_for_edge: int = attr.ib()
   length: float = attr.ib()
+  true_length: float = attr.ib()
   oneway: int = attr.ib()
   highway: Text = attr.ib()
   osmid: int = attr.ib()
@@ -59,6 +60,7 @@ class Edge:
       u_for_edge,
       v_for_edge,
       max(0.001, length),
+      length,
       False,
       highway,
       osmid,
@@ -67,7 +69,12 @@ class Edge:
     )
 
   @classmethod
-  def from_poi(cls, u_for_edge, v_for_edge, osmid, length, geometry):
+  def from_poi(cls, 
+              u_for_edge, 
+              v_for_edge, 
+              osmid, length, 
+              true_length, 
+              geometry):
     """Construct an edge entity to connect a POI.
     Arguments:
       u_for_edge: The u endside of the edge.
@@ -81,6 +88,7 @@ class Edge:
       u_for_edge,
       v_for_edge,
       max(0.001, length),
+      true_length,
       False,
       "poi",
       osmid,

--- a/cabby/geo/map_processing/map_structure.py
+++ b/cabby/geo/map_processing/map_structure.py
@@ -40,6 +40,7 @@ from cabby.geo import regions
 
 POI_PREFIX = '#'
 SHOW_PROGRESS_EVERY = 100
+ADD_POI_DISTANCE = 5000
 
 class Map:
 
@@ -301,7 +302,7 @@ class Map:
       v_for_edge=projected_point_osmid,
       osmid=near_edge['osmid'],
       geometry=projected_line,
-      length = projected_line_dist
+      length = projected_line_dist + ADD_POI_DISTANCE
     )
     edges_list.append(edge_to_add)
 

--- a/cabby/geo/map_processing/map_structure.py
+++ b/cabby/geo/map_processing/map_structure.py
@@ -62,10 +62,9 @@ class Map:
       logging.info("Constructing graph.")
       self.nx_graph = ox.graph_from_polygon(
         self.polygon_area, network_type='walk')
-      distance=nx.get_edge_attributes(self.nx_graph,'length')
+      distance = nx.get_edge_attributes(self.nx_graph, 'length')
       nx.set_edge_attributes(self.nx_graph, distance, 'true_length')
       
-
       logging.info("Add POI to graph.")
       self.add_poi_to_graph()
       self.nodes, self.edges = ox.graph_to_gdfs(self.nx_graph)
@@ -86,7 +85,8 @@ class Map:
 
     # Drop columns with list type.
     self.edges.drop(self.edges.columns.difference(
-      ['osmid', 'true_length','length', 'geometry', 'u', 'v', 'key']), 1, inplace=True)
+      ['osmid', 'true_length', 'length', 'geometry', 'u', 'v', 'key']), 
+      1, inplace=True)
     self.edges['osmid'] = self.edges['osmid'].apply(lambda x: str(x))
 
   def get_poi(self) -> Tuple[GeoSeries, GeoSeries]:
@@ -130,7 +130,8 @@ class Map:
     if self.num_poi_add%SHOW_PROGRESS_EVERY == 0:
       percentage_gen = round(100*self.num_poi_add/self.num_poi)
       logging.info(
-        f"Number of POI add to graph {self.num_poi_add}, that is {percentage_gen}% of the required POI addition.")
+        f"Number of POI add to graph {self.num_poi_add}, " + 
+        f"that is {percentage_gen}% of the required POI addition.")
 
     # If the POI is already in the graph, do not add it.
     if single_poi['osmid'] in self.nx_graph:
@@ -227,7 +228,8 @@ class Map:
     projected point: (a) u-projected point; (b) v-projected point; (5) remove 
     closest edge u-v.
     Arguments:
-      point_exterior: a point on the exterior of a POI that will be projected on to the closest edge.
+      point_exterior: a point on the exterior of a POI that will be projected 
+      on to the closest edge.
       list_edges_connected_ids: list of edges ids already connected to the POI. 
       If the current edge found is already connected it will avoid connecting 
       it again.

--- a/cabby/geo/map_processing/map_structure.py
+++ b/cabby/geo/map_processing/map_structure.py
@@ -40,6 +40,8 @@ from cabby.geo import regions
 
 POI_PREFIX = '#'
 SHOW_PROGRESS_EVERY = 100
+# Addition of distance to POI edges in order to prevent shhortcut route through 
+# the POI node.
 ADD_POI_DISTANCE = 5000
 
 class Map:

--- a/cabby/geo/map_processing/map_test.py
+++ b/cabby/geo/map_processing/map_test.py
@@ -44,7 +44,6 @@ class MapTest(unittest.TestCase):
     node = self.map.nx_graph.nodes['1#1360050503']
     self.assertEqual('primary', node['highway'])
 
-
   def testSingleOutput(self):
     # Verify that a known POI is present.
 
@@ -60,10 +59,6 @@ class MapTest(unittest.TestCase):
     found_ids = [list_cells[i].id() for i in range(len(list_cells))]
     for expected, found in zip(expected_ids, found_ids):
       self.assertEqual(expected, found)
-
-    
-
-  
 
 
 if __name__ == "__main__":

--- a/cabby/geo/map_processing/map_test.py
+++ b/cabby/geo/map_processing/map_test.py
@@ -14,7 +14,8 @@
 
 '''Tests for map_structure.py'''
 
-
+import sys
+sys.path.append("/home/tzuf_google_com/dev/cabby")
 
 import collections
 import osmnx as ox

--- a/cabby/geo/walk.py
+++ b/cabby/geo/walk.py
@@ -196,7 +196,8 @@ class Walker:
     try:
       # Find nodes within 2000 meter path distance.
       outer_circle_graph = ox.truncate.truncate_graph_dist(
-      self.map.nx_graph, dest_osmid, max_dist=(MAX_PATH_DIST+2*ADD_POI_DISTANCE), weight='length')
+        self.map.nx_graph, dest_osmid, 
+        max_dist=(MAX_PATH_DIST+2*ADD_POI_DISTANCE), weight='length')
 
       outer_circle_graph_osmid = list(outer_circle_graph.nodes.keys())
     except nx.exception.NetworkXPointlessConcept:  # GeoDataFrame returned empty
@@ -205,7 +206,8 @@ class Walker:
     try:
       # Get graph that is too close (less than 200 meter path distance)
       inner_circle_graph = ox.truncate.truncate_graph_dist(
-        self.map.nx_graph, dest_osmid, max_dist=MIN_PATH_DIST+2*ADD_POI_DISTANCE, weight='length')
+        self.map.nx_graph, dest_osmid, 
+        max_dist=MIN_PATH_DIST + 2 * ADD_POI_DISTANCE, weight='length')
       inner_circle_graph_osmid = list(inner_circle_graph.nodes.keys())
 
     except nx.exception.NetworkXPointlessConcept:  # GeoDataFrame returned empty
@@ -305,9 +307,10 @@ class Walker:
       A single landmark near the goal location.
     '''
 
-    near_poi_con = self.map.poi.apply(lambda x: util.get_distance_between_geometries(
-      x.geometry, end_point['centroid']) < NEAR_PIVOT_DIST + 
-      2*ADD_POI_DISTANCE, axis=1)
+    near_poi_con = self.map.poi.apply(
+      lambda x: util.get_distance_between_geometries(
+        x.geometry, 
+        end_point['centroid']) < NEAR_PIVOT_DIST + 2 * ADD_POI_DISTANCE, axis=1)
 
     poi = self.map.poi[near_poi_con]
     

--- a/cabby/geo/walk.py
+++ b/cabby/geo/walk.py
@@ -306,7 +306,8 @@ class Walker:
     '''
 
     near_poi_con = self.map.poi.apply(lambda x: util.get_distance_between_geometries(
-      x.geometry, end_point['centroid']) < NEAR_PIVOT_DIST+ADD_POI_DISTANCE, axis=1)
+      x.geometry, end_point['centroid']) < NEAR_PIVOT_DIST + 
+      2*ADD_POI_DISTANCE, axis=1)
 
     poi = self.map.poi[near_poi_con]
     

--- a/cabby/geo/walk_test.py
+++ b/cabby/geo/walk_test.py
@@ -43,7 +43,7 @@ class WalkTest(unittest.TestCase):
                    nx_graph, self.map.nodes)
 
     # Check the size of the route.
-    self.assertEqual(route['geometry'].shape[0], 25)
+    self.assertEqual(route['geometry'].shape[0], 26)
 
     # Check that the correct points are in the route.
     first_point = util.tuple_from_point(route.iloc[0]['geometry'])
@@ -60,7 +60,7 @@ class WalkTest(unittest.TestCase):
     self.assertEqual(geo_entity.start_point['osmid'], '#2984603460')
     self.assertEqual(geo_entity.end_point['osmid'], '#1362253177')
     self.assertEqual(geo_entity.main_pivot['osmid'], '#91900570')
-    self.assertEqual(geo_entity.near_pivot['osmid'], '#751864718')
+    self.assertEqual(geo_entity.near_pivot['osmid'], '#2975872267')
     self.assertEqual(geo_entity.intersections, 1)
 
 


### PR DESCRIPTION
In the current situation a POI might be connected to multiple edges. When calculating the shortest route it might go through the POI node as if it is connected to two or more edges. To solve this the length of the POI edges was raised so that the shortest route wouldn't go through the POI node.